### PR TITLE
KX-18559 Ensure usages extraction for the Text widget

### DIFF
--- a/src/Kentico.Xperience.Mjml.StarterKit.Rcl/Widgets/TextWidget/TextWidgetProperties.cs
+++ b/src/Kentico.Xperience.Mjml.StarterKit.Rcl/Widgets/TextWidget/TextWidgetProperties.cs
@@ -1,4 +1,8 @@
-﻿namespace Kentico.Xperience.Mjml.StarterKit.Rcl.Widgets;
+﻿using CMS.ContentEngine;
+
+using Kentico.EmailBuilder.Web.Mvc;
+
+namespace Kentico.Xperience.Mjml.StarterKit.Rcl.Widgets;
 
 /// <summary>
 /// Configurable properties of the <see cref="TextWidget"/>.
@@ -8,5 +12,6 @@ public sealed class TextWidgetProperties : WidgetPropertiesBase
     /// <summary>
     /// The widget content.
     /// </summary>
+    [TrackContentItemReference(typeof(ContentItemReferenceExtractor))]
     public string Text { get; set; } = string.Empty;
 }


### PR DESCRIPTION
# Motivation

In next release there will be option to insert page/asset links into the Text widget so we need to ensure that the usages for the underlying property are correctly tracked.
