### PR TITLE
Fix/button widget bug

### DIFF
--- a/src/Kentico.Xperience.Mjml.StarterKit.Rcl/Widgets/ButtonWidget/ButtonWidget.razor
+++ b/src/Kentico.Xperience.Mjml.StarterKit.Rcl/Widgets/ButtonWidget/ButtonWidget.razor
@@ -10,8 +10,8 @@
 }
 else
 {
-    <mj-text css-class="@Properties.CssClass">
-        <a align="@Properties.ButtonHorizontalAlignment" href="@Properties.Url">
+    <mj-text align="@Properties.ButtonHorizontalAlignment" css-class="@Properties.CssClass">
+        <a href="@Properties.Url">
             @Properties.Text
         </a>
     </mj-text>


### PR DESCRIPTION
# Motivation

Fix alignment on link

## Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

In Mjml email template add button widget and set alignment to center.

Expected behavior:
- link will be centered
